### PR TITLE
Google analytics tracking code extracted to seperate file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,9 +32,7 @@ inc:
   
  # Analytics     
   analytics:
-    google: 
-      # eg. 'UA-123-12'
-      id:       false
+    google: false # Add tracking code in _includes/_google-analytics.html
       
       
   # Google Fonts

--- a/_includes/_google-analytics.html
+++ b/_includes/_google-analytics.html
@@ -1,0 +1,1 @@
+<!--google analytics tracking code here-->

--- a/_includes/_scripts.html
+++ b/_includes/_scripts.html
@@ -24,12 +24,6 @@
         s.parentNode.insertBefore(g, s);
     }(document, 'script'));
 </script>{% endif %}
-{% if site.inc.analytics.google.id %}<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ site.inc.analytics.google.id }}', '{{ site.url }}');
-  ga('send', 'pageview');
-</script>{% endif %}
+{% if site.inc.analytics.google %}
+  {% include _google-analytics.html %}
+{% endif %}


### PR DESCRIPTION
I have extracted the analytics script generation to be manually included in `_includes/_google-analytics.html`

The reasoning behind this is google analytics has [different variations](https://github.com/kippt/jekyll-incorporated/issues/8) of scripts, which makes it complex to give a standardized solution based on property id.

So, I've added a file, where users can place their flavor of analytics code.
