### PR TITLE
Removed "timezone: nil"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,6 @@ plugins:     ./_plugins
 layouts:     ./_layouts
 include:     ['.htaccess']
 exclude:     []
-timezone:    nil
 
 # Show future posts
 future:      false


### PR DESCRIPTION
Hi,

My blog (https://toepoke.github.io/) was forked from your excellent incorporated theme.

A week or so ago it stopped building.  I guess github updated something.

Anyways, I tracked it down to the "timezone: nil" setting in the "_config.yml".

Hope this helps.

Kind regards,
Franz.